### PR TITLE
fix - ip6tables-restore v1.8.7 (nf_tables): unknown reject type "icmp…

### DIFF
--- a/grommunio-setup
+++ b/grommunio-setup
@@ -655,7 +655,7 @@ cat >/etc/iptables/rules.v6 <<EOF
 -A INPUT -p tcp -m tcp --dport 8443 -j ACCEPT
 -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -j REJECT --reject-with icmp-port-unreachable
+-A INPUT -j REJECT
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
 COMMIT


### PR DESCRIPTION
…-port-unreachable"