### PR TITLE
cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/eryx12o45/grommunio-setup.git /usr/local/share/grom
 ```
 mkdir /root/rpmconv
 cd /root/rpmconv
-apt install -y alien
+apt-get install -y alien
 wget https://download.grommunio.com/community/openSUSE_Leap_15.3/grommunio-index-0.1.11.8787c3c-lp153.17.1.x86_64.rpm
 alien grommunio-index-0.1.11.8787c3c-lp153.17.1.x86_64.rpm
 dpkg -i grommunio-index_0.1.11.8787c3c-1_amd64.deb

--- a/common/repo
+++ b/common/repo
@@ -16,7 +16,7 @@ Components: main
 SOURCES
 
   apt-get update 2>&1 | tee -a "$LOGFILE"
-  apt-get install -y "${PACKAGES}" 2>&1 | tee -a "$LOGFILE"
+  apt-get install -y ${PACKAGES} 2>&1 | tee -a "$LOGFILE"
   dpkg -i "${DATADIR}/temp_packages/grommunio-antispam_amd64.deb"
   echo
   echo -e " \x1b[36m▼\x1b[0m operation completed"

--- a/common/repo
+++ b/common/repo
@@ -7,11 +7,16 @@ setup_repo() {
   echo
   echo -e " \x1b[36m▼\x1b[0m grommunio-setup is updating the system"
   echo
-  wget -O - https://download.grommunio.com/RPM-GPG-KEY-grommunio | apt-key add - 2>&1 | tee -a "$LOGFILE"
-  echo "deb [trusted=yes] https://download.grommunio.com/community/Debian_11 Debian_11 main" > /etc/apt/sources.list.d/grommunio.list
+  wget -q https://download.grommunio.com/RPM-GPG-KEY-grommunio -O /etc/apt/trusted.gpg.d/download.grommunio.com.asc
+cat << SOURCES > /etc/apt/sources.list.d/grommunio-community.sources
+Types: deb
+URIs: https://download.grommunio.com/community/Debian_11
+Suites: Debian_11
+Components: main
+SOURCES
 
-  apt update 2>&1 | tee -a "$LOGFILE"
-  apt install -y ${PACKAGES} 2>&1 | tee -a "$LOGFILE"
+  apt-get update 2>&1 | tee -a "$LOGFILE"
+  apt-get install -y "${PACKAGES}" 2>&1 | tee -a "$LOGFILE"
   dpkg -i "${DATADIR}/temp_packages/grommunio-antispam_amd64.deb"
   echo
   echo -e " \x1b[36m▼\x1b[0m operation completed"

--- a/common/ssl_setup
+++ b/common/ssl_setup
@@ -77,7 +77,7 @@ owncert() {
 letsencrypt() {
 
   progress 0
-  apt install -y python3-certbot python3-certbot-nginx nginx >>"${LOGFILE}" 2>&1
+  apt-get install -y python3-certbot python3-certbot-nginx nginx >>"${LOGFILE}" 2>&1
   progress 60
   {
     firewall-cmd --add-port=80/tcp --zone=public --permanent

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: 2021 grommunio GmbH
 # Interactive grommunio setup
 
-apt update
-apt install -y dialog
+apt-get update
+apt-get install -y dialog
 
 DATADIR="${0%/*}"
 if [ "${DATADIR}" = "$0" ]; then
@@ -26,14 +26,14 @@ fi
 TMPF=$(mktemp /tmp/setup.sh.XXXXXXXX)
 
 # make sure necessary packages are installed
-apt update >>"${LOGFILE}" 2>&1
-apt upgrade -y >>"${LOGFILE}" 2>&1
+apt-get update >>"${LOGFILE}" 2>&1
+apt-get dist-upgrade -y >>"${LOGFILE}" 2>&1
 echo "postfix	postfix/mailname string $DOMAIN" | debconf-set-selections
 echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
 SYSTEM_PACKAGES="mariadb-server mariadb-client redis nginx postfix postfix-mysql php php-igbinary \
 php-redis sqlite3 php7.4 php7.4-fpm curl fetchmail rspamd certbot python3-certbot-nginx libsasl2-2 libsasl2-modules \
 sasl2-bin jq gnupg2 iptables iptables-persistent clamav clamav-freshclam clamav-daemon"
-DEBIAN_FRONTEND=noninteractive apt install -y ${SYSTEM_PACKAGES} >>"${LOGFILE}" 2>&1
+DEBIAN_FRONTEND=noninteractive apt-get install -y ${SYSTEM_PACKAGES} >>"${LOGFILE}" 2>&1
 
 writelog "Welcome dialog"
 dialog_welcome

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -449,11 +449,11 @@ systemctl enable --now mariadb >>"${LOGFILE}" 2>&1
 # https://community.grommunio.com/d/447-debian-11-clean-install-script/37
 mkdir -p /var/spool/postfix/run/mysqld >>"${LOGFILE}" 2>&1
 # shellcheck disable=SC2028
-if ! grep -qF -- "/run/mysqld" /etc/fstab; then echo -e -n \
-  "/run/mysqld\t/var/spool/postfix/run/mysqld\tbind\tdefaults,bind\t0\t0\n" | \
+if ! grep -qF -- "/run/mysqld" /etc/fstab; then 
+  echo -e "/run/mysqld\t/var/spool/postfix/run/mysqld\tbind\tdefaults,bind\t0\t0" | \
   tee -a /etc/fstab >>"${LOGFILE}" 2>&1
-mount /var/spool/postfix/run/mysqld >>"${LOGFILE}" 2>&1
-
+  mount /var/spool/postfix/run/mysqld >>"${LOGFILE}" 2>&1
+fi
 writelog "Config stage: put php files into place"
 if [ -e "/etc/php/7.4/fpm/php-fpm.conf.default" ]; then
   mv /etc/php/7.4/fpm/php-fpm.conf.default /etc/php/7.4/fpm/php-fpm.conf >>"${LOGFILE}" 2>&1

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -103,7 +103,6 @@ cat >/etc/grommunio-common/nginx/ssl_certificate.conf <<EOF
 ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
 ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
 EOF
-ln -s /etc/grommunio-common/nginx/ssl_certificate.conf /etc/grommunio-admin-common/nginx-ssl.conf
 
 # shellcheck source=common/repo
 PACKAGES="gromox grommunio-admin-api grommunio-admin-web grommunio-admin-common \
@@ -111,6 +110,8 @@ PACKAGES="gromox grommunio-admin-api grommunio-admin-web grommunio-admin-common 
   system-user-groweb system-user-grosync system-user-grodav"
 . "${DATADIR}/common/repo"
 setup_repo
+
+ln -s /etc/grommunio-common/nginx/ssl_certificate.conf /etc/grommunio-admin-common/nginx-ssl.conf
 
 MYSQL_HOST="localhost"
 MYSQL_USER="grommunio"

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -546,7 +546,7 @@ grommunio-admin passwd --password "${ADMIN_PASS}" >>"${LOGFILE}" 2>&1
 rspamadm pw -p "${ADMIN_PASS}" | sed -e 's#^#password = "#' -e 's#$#";#' >/etc/grommunio-antispam/local.d/worker-controller.inc
 
 writelog "Add nginx config for rspamd"
-cat >/etc/grommunio-admin-common/nginx.d/rspamd.conf <<EOF
+cat >/etc/grommunio-admin-common/nginx.d/rspamd.conf <<'EOF'
 location /rspamd/ {
     proxy_pass       http://localhost:11334/;
     proxy_set_header Host      $host;

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -459,8 +459,8 @@ fi
 if [ ! -e "/etc/php/7.4/fpm/pool.d/gromox.conf" ]; then
   cp -f /usr/share/gromox/fpm-gromox.conf.sample /etc/php/7.4/fpm/pool.d/gromox.conf >>"${LOGFILE}" 2>&1
 fi
-if [ ! -e "/etc/php/7.4/fpm/pool.d/pool-grommunio-web.conf" ]; then
-  ln -s /etc/php/7.4/fpm/php-fpm.d/pool-grommunio-web.conf /etc/php/7.4/fpm/pool.d/ >>"${LOGFILE}" 2>&1
+#if [ ! -e "/etc/php/7.4/fpm/pool.d/pool-grommunio-web.conf" ]; then
+#  ln -s /etc/php/7.4/fpm/php-fpm.d/pool-grommunio-web.conf /etc/php/7.4/fpm/pool.d/ >>"${LOGFILE}" 2>&1
 fi
 if [ ! -e "/etc/php/7.4/fpm/pool.d/pool-grommunio-sync.conf" ]; then
   ln -s /etc/php/7.4/fpm/php-fpm.d/pool-grommunio-sync.conf /etc/php/7.4/fpm/pool.d/ >>"${LOGFILE}" 2>&1

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -765,7 +765,8 @@ writelog "Config stage: restart all required services"
 systemctl restart redis@grommunio.service nginx.service php7.4-fpm.service gromox-delivery.service \
   gromox-event.service gromox-http.service gromox-imap.service gromox-midb.service grommunio-antispam.service \
   gromox-pop3.service gromox-delivery-queue.service gromox-timer.service gromox-zcore.service \
-  grommunio-admin-api.service saslauthd.service clamav-freshclam.service clamav-daemon.service >>"${LOGFILE}" 2>&1
+  grommunio-admin-api.service saslauthd.service clamav-freshclam.service clamav-daemon.service \
+  grommunio-spam-run.service >>"${LOGFILE}" 2>&1
 
 mv /tmp/config.json /etc/grommunio-admin-common/config.json
 systemctl restart grommunio-admin-api.service

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -463,7 +463,7 @@ if [ ! -e "/etc/php/7.4/fpm/pool.d/gromox.conf" ]; then
 fi
 #if [ ! -e "/etc/php/7.4/fpm/pool.d/pool-grommunio-web.conf" ]; then
 #  ln -s /etc/php/7.4/fpm/php-fpm.d/pool-grommunio-web.conf /etc/php/7.4/fpm/pool.d/ >>"${LOGFILE}" 2>&1
-fi
+#fi
 if [ ! -e "/etc/php/7.4/fpm/pool.d/pool-grommunio-sync.conf" ]; then
   ln -s /etc/php/7.4/fpm/php-fpm.d/pool-grommunio-sync.conf /etc/php/7.4/fpm/pool.d/ >>"${LOGFILE}" 2>&1
 fi

--- a/grommunio-setup
+++ b/grommunio-setup
@@ -449,7 +449,9 @@ systemctl enable --now mariadb >>"${LOGFILE}" 2>&1
 # https://community.grommunio.com/d/447-debian-11-clean-install-script/37
 mkdir -p /var/spool/postfix/run/mysqld >>"${LOGFILE}" 2>&1
 # shellcheck disable=SC2028
-echo -e -n "/run/mysqld\t/var/spool/postfix/run/mysqld\tbind\tdefaults,bind\t0\t0\n" | tee -a /etc/fstab >>"${LOGFILE}" 2>&1
+if ! grep -qF -- "/run/mysqld" /etc/fstab; then echo -e -n \
+  "/run/mysqld\t/var/spool/postfix/run/mysqld\tbind\tdefaults,bind\t0\t0\n" | \
+  tee -a /etc/fstab >>"${LOGFILE}" 2>&1
 mount /var/spool/postfix/run/mysqld >>"${LOGFILE}" 2>&1
 
 writelog "Config stage: put php files into place"


### PR DESCRIPTION
- Transition to deb822 .sources - `man sources.list`
  - Getting rid of unsafe trusted-usage in the process
- apt isn't intended to be used in scripts - `man apt` SCRIPT USAGE...